### PR TITLE
feat: new helper – value

### DIFF
--- a/src/tokens/generateHelpers.test.ts
+++ b/src/tokens/generateHelpers.test.ts
@@ -39,6 +39,7 @@ describe("generateHelpers", () => {
 			"spacing",
 			"typography",
 			"transitionTime",
+			"value",
 		]);
 	});
 
@@ -114,5 +115,14 @@ describe("generateHelpers", () => {
 			// @ts-expect-error -- should error on non-existent breakpoint
 			mediaQuery.max("does not exist")({ theme: themeWithBreakpoints }),
 		).toBe("@media (max-width: undefined)");
+	});
+
+	it("should generate value helper for any scalar value", () => {
+		const { value } = generateHelpers(theme);
+
+		expect(value("typography.heading.lineHeight")({ theme })).toBe("14px");
+
+		// @ts-expect-error -- should complain about invalid paths
+		expect(value("invalid.path")({ theme })).toBeUndefined();
 	});
 });

--- a/src/tokens/generateHelpers.ts
+++ b/src/tokens/generateHelpers.ts
@@ -72,7 +72,15 @@ type Helpers<
 				) => (props: { theme: Theme }) => string;
 			};
 	  }
-	: Record<string, never>);
+	: Record<string, never>) & {
+		value: <Path extends ScalarPaths<Theme>>(
+			path: Path,
+		) => (props: {
+			theme: Theme;
+			// The `Path extends string` is a trick to force compiler to defer execution of the condition.
+			// Otherwise, we get infinite depth issue.
+		}) => Path extends string ? ObjectPathValue<Theme, Path> : never;
+	};
 
 const constructMediaQuery = <
 	BreakpointsKey extends string,
@@ -150,5 +158,13 @@ export const generateHelpers = <
 							// eslint-disable-next-line @typescript-eslint/no-explicit-any -- a bit too hard to type this
 					  ] as any)
 					: [],
-			),
+			)
+			.concat([
+				[
+					"value",
+					(path: string) =>
+						({ theme }: { theme: Theme }) =>
+							get(theme, path),
+				],
+			]),
 	) as Helpers<Theme, SpacingKey, BreakpointsKey, ObjectKeys>;


### PR DESCRIPTION
Helps retrieve any value in theme, without prefix. This might eventually replace all other helpers.

This one is actually new and is useful for some use-cases where `fromTheme` helper was used previously. Basically, allows reference any value in theme declaratively using path.