### PR TITLE
fix: use future-proof import path

### DIFF
--- a/src/tokens/generateHelpers.ts
+++ b/src/tokens/generateHelpers.ts
@@ -1,5 +1,5 @@
 import { type GetFieldType } from "lodash";
-import get from "lodash-es/get";
+import get from "lodash-es/get.js";
 
 import {
 	type ObjectPaths,


### PR DESCRIPTION
This just helps us avoid having custom config in `louis` and `lokalise-main` as the lodash-es package is marked as `type: module` and ES standard requires extensions for module imports.